### PR TITLE
fix: saved group settings now load correctly

### DIFF
--- a/src/settings/categories/GroupSettings.ts
+++ b/src/settings/categories/GroupSettings.ts
@@ -8,7 +8,11 @@ export class GroupSettings {
 	}
 
 	public static fromStore(store: any) {
-		return new GroupSettings(store?.groups);
+		return new GroupSettings(
+			store?.groups.flatMap((nodeGroup: any) => {
+				return new NodeGroup(nodeGroup.query, nodeGroup.color);
+			})
+		)
 	}
 
 	public toObject() {


### PR DESCRIPTION
Fixes #22 

Currently, the plugin is missing logic for loading stored group settings back into `NodeGroup` types, so they are loaded as generic associative arrays. This causes the group settings tab to become unresponsive on new Obsidian sessions.

This change adds these instructions for loading each group setting as a `NodeGroup` type.