### PR TITLE
feat: group nodes by tag

### DIFF
--- a/src/graph/Node.ts
+++ b/src/graph/Node.ts
@@ -1,5 +1,5 @@
 import Link from "./Link";
-import { TFile } from "obsidian";
+import { TFile, getAllTags } from "obsidian";
 
 export default class Node {
 	public readonly id: string;
@@ -9,13 +9,15 @@ export default class Node {
 
 	public readonly neighbors: Node[];
 	public readonly links: Link[];
+	public readonly tags: string[];
 
 	constructor(
 		name: string,
 		path: string,
 		val = 10,
 		neighbors: Node[] = [],
-		links: Link[] = []
+		links: Link[] = [],
+		tags: string[] = []
 	) {
 		this.id = path;
 		this.name = name;
@@ -23,6 +25,7 @@ export default class Node {
 		this.val = val;
 		this.neighbors = neighbors;
 		this.links = links;
+		this.tags = tags;
 	}
 
 	// Creates an array of nodes from an array of files (from the Obsidian API)
@@ -32,6 +35,11 @@ export default class Node {
 			files
 				.map((file, index) => {
 					const node = new Node(file.name, file.path);
+					const cache = app.metadataCache.getFileCache(file),
+						tags = cache ? getAllTags(cache) : null;
+					if (tags != null) {
+						tags.forEach((tag) => node.tags.push(tag));
+					}
 					if (!nodeMap.has(node.id)) {
 						nodeMap.set(node.id, index);
 						return node;

--- a/src/graph/Node.ts
+++ b/src/graph/Node.ts
@@ -38,7 +38,8 @@ export default class Node {
 					const cache = app.metadataCache.getFileCache(file),
 						tags = cache ? getAllTags(cache) : null;
 					if (tags != null) {
-						tags.forEach((tag) => node.tags.push(tag));
+						// stores tags without leading octothorpe `#` as ["tag1", "tag2", ...]
+						tags.forEach((tag) => node.tags.push(tag.substring(1)));
 					}
 					if (!nodeMap.has(node.id)) {
 						nodeMap.set(node.id, index);

--- a/src/settings/categories/GroupSettings.ts
+++ b/src/settings/categories/GroupSettings.ts
@@ -32,8 +32,11 @@ export class NodeGroup {
 	}
 
 	static matches(query: string, node: Node): boolean {
-		return node.path.startsWith(this.sanitizeQuery(query)) ||
-		node.tags.includes(query);
+		// queries tags if query begins with "tag:" or "tag:#"
+		if (query.match(/^tag:#?/)) {
+			return node.tags.includes(query.replace(/^tag:#?/, "")) 
+		}
+		return node.path.startsWith(this.sanitizeQuery(query))
 	}
 
 	static sanitizeQuery(query: string): string {

--- a/src/settings/categories/GroupSettings.ts
+++ b/src/settings/categories/GroupSettings.ts
@@ -32,7 +32,8 @@ export class NodeGroup {
 	}
 
 	static matches(query: string, node: Node): boolean {
-		return node.path.startsWith(this.sanitizeQuery(query));
+		return node.path.startsWith(this.sanitizeQuery(query)) ||
+		node.tags.includes(query);
 	}
 
 	static sanitizeQuery(query: string): string {


### PR DESCRIPTION
Resolves #14

Adds support for highlighting notes based on tags.

A query matching all notes with the `math` tag can look like either of the following:

+ `tag:math`
+ `tag:#math`

<ins>Please review</ins> lines 38 through 43 in `src/graph/Node.ts`, it's very messy!