### PR TITLE
feat: toggle attachment visibility

### DIFF
--- a/src/graph/Link.ts
+++ b/src/graph/Link.ts
@@ -5,10 +5,12 @@ export type ResolvedLinkCache = Record<string, Record<string, number>>;
 export default class Link {
 	public readonly source: string;
 	public readonly target: string;
+	public readonly linksAnAttachment: boolean;
 
-	constructor(sourceId: string, targetId: string) {
+	constructor(sourceId: string, targetId: string, linksAnAttachment: boolean) {
 		this.source = sourceId;
 		this.target = targetId;
+		this.linksAnAttachment = linksAnAttachment;
 	}
 
 	// Creates a link index for an array of links

--- a/src/graph/Node.ts
+++ b/src/graph/Node.ts
@@ -5,6 +5,7 @@ export default class Node {
 	public readonly id: string;
 	public readonly name: string;
 	public readonly path: string;
+	public readonly isAttachment: boolean;
 	public readonly val: number; // = weight, currently = 1 because scaling doesn't work well
 
 	public readonly neighbors: Node[];
@@ -14,6 +15,7 @@ export default class Node {
 	constructor(
 		name: string,
 		path: string,
+		isAttachment: boolean,
 		val = 10,
 		neighbors: Node[] = [],
 		links: Link[] = [],
@@ -22,6 +24,7 @@ export default class Node {
 		this.id = path;
 		this.name = name;
 		this.path = path;
+		this.isAttachment = isAttachment;
 		this.val = val;
 		this.neighbors = neighbors;
 		this.links = links;
@@ -34,7 +37,7 @@ export default class Node {
 		return [
 			files
 				.map((file, index) => {
-					const node = new Node(file.name, file.path);
+					const node = new Node(file.name, file.path, file.extension == "md" ? false : true);
 					const cache = app.metadataCache.getFileCache(file),
 						tags = cache ? getAllTags(cache) : null;
 					if (tags != null) {

--- a/src/graph/Node.ts
+++ b/src/graph/Node.ts
@@ -58,7 +58,7 @@ export default class Node {
 	// Links together two nodes as neighbors (node -> neighbor)
 	addNeighbor(neighbor: Node): Link | null {
 		if (!this.isNeighborOf(neighbor)) {
-			const link = new Link(this.id, neighbor.id);
+			const link = new Link(this.id, neighbor.id, this.isAttachment || neighbor.isAttachment);
 			this.neighbors.push(neighbor);
 			this.addLink(link);
 

--- a/src/settings/categories/FilterSettings.ts
+++ b/src/settings/categories/FilterSettings.ts
@@ -1,17 +1,20 @@
 export class FilterSettings {
 	doShowOrphans? = true;
+	doShowAttachments? = false;
 
-	constructor(doShowOrphans?: boolean) {
+	constructor(doShowOrphans?: boolean, doShowAttachments?: boolean) {
 		this.doShowOrphans = doShowOrphans ?? this.doShowOrphans;
+		this.doShowAttachments = doShowAttachments ?? this.doShowAttachments;
 	}
 
 	public static fromStore(store: any) {
-		return new FilterSettings(store?.doShowOrphans);
+		return new FilterSettings(store?.doShowOrphans, store?.doShowAttachments);
 	}
 
 	public toObject() {
 		return {
 			doShowOrphans: this.doShowOrphans,
+			doShowAttachments: this.doShowAttachments,
 		};
 	}
 }

--- a/src/views/graph/ForceGraph.ts
+++ b/src/views/graph/ForceGraph.ts
@@ -136,10 +136,10 @@ export class ForceGraph {
 
 	private doShowNode = (node: Node) => {
 		return (
-			this.plugin.getSettings().filters.doShowOrphans ||
-			node.links.length > 0 &&
-			this.plugin.getSettings().filters.doShowAttachments ||
-			!node.isAttachment
+			(this.plugin.getSettings().filters.doShowOrphans ||
+			node.links.length > 0) &&
+			(this.plugin.getSettings().filters.doShowAttachments ||
+			!node.isAttachment)
 		);
 	};
 

--- a/src/views/graph/ForceGraph.ts
+++ b/src/views/graph/ForceGraph.ts
@@ -143,6 +143,10 @@ export class ForceGraph {
 		);
 	};
 
+	private doShowLink = (link: Link) => {
+		return this.plugin.getSettings().filters.doShowAttachments || !link.linksAnAttachment
+	}
+
 	private onNodeHover = (node: Node | null) => {
 		if (
 			(!node && !this.highlightedNodes.size) ||
@@ -189,6 +193,7 @@ export class ForceGraph {
 			.linkDirectionalParticleWidth(
 				this.plugin.getSettings().display.particleSize
 			)
+			.linkVisibility(this.doShowLink)
 			.onLinkHover(this.onLinkHover)
 			.linkColor((link: Link) =>
 				this.isHighlightedLink(link)

--- a/src/views/graph/ForceGraph.ts
+++ b/src/views/graph/ForceGraph.ts
@@ -137,7 +137,9 @@ export class ForceGraph {
 	private doShowNode = (node: Node) => {
 		return (
 			this.plugin.getSettings().filters.doShowOrphans ||
-			node.links.length > 0
+			node.links.length > 0 &&
+			this.plugin.getSettings().filters.doShowAttachments ||
+			!node.isAttachment
 		);
 	};
 

--- a/src/views/settings/categories/FilterSettingsView.ts
+++ b/src/views/settings/categories/FilterSettingsView.ts
@@ -13,6 +13,13 @@ const FilterSettingsView = (
 				filterSettings.value.doShowOrphans = value;
 			});
 	});
+	new Setting(containerEl).setName("Show Attachments").addToggle((toggle) => {
+		toggle
+			.setValue(filterSettings.value.doShowAttachments || false)
+			.onChange(async (value) => {
+				filterSettings.value.doShowAttachments = value;
+			});
+	});
 };
 
 export default FilterSettingsView;


### PR DESCRIPTION
Resolves #34 

> [!IMPORTANT]
> An attachment is any file that does __not__ have a `.md` extension (Line 40 of `src/graph/Node.ts`)
> 
> The default state of "Show Attachments" is __false__ (Line 3 of `src/settings/categories/FilterSettings.ts`)

Adds the option to toggle the visibility of attachments.

Along with hiding attachment nodes themselves, their incoming and outgoing links are hidden as well.

> [!WARNING]
> This toggle does NOT alter graph physics whatsoever. Files remain physically linked regardless of the visibility of their mutual attachments.

<img width="622" alt="showAttachments" src="https://github.com/AlexW00/obsidian-3d-graph/assets/33991373/9792a2ca-c713-4612-beb4-69035b792888">